### PR TITLE
Fix exposing of ports.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,12 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # Install dependencies
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    nginx \
-    expect \
-    tcl \
-    libgdiplus && \
-    rm -rf /var/lib/apt/lists/*
+	apt-get install -y --no-install-recommends \
+	nginx \
+	expect \
+	tcl \
+	libgdiplus && \
+	rm -rf /var/lib/apt/lists/*
 
 # Remove default nginx stuff
 RUN rm -fr /usr/share/nginx/html/* && \
@@ -70,7 +70,7 @@ WORKDIR /
 
 # Expose necessary ports
 EXPOSE 8080
-EXPOSE 28015
+EXPOSE 28015/udp
 EXPOSE 28016
 
 # Setup default environment variables for the server


### PR DESCRIPTION
Noticed that by default EXPOSE only exposes TCP. You have to explicitly expose UDP as seen in my PR.

I ran into this when adding RustIO. Rust uses 28015/udp and RustIO uses 28015/tcp for callback authentication with the server.