### PR TITLE
Follow HTTP301 redirect on getting Oxide Releases Page

### DIFF
--- a/start_rust.sh
+++ b/start_rust.sh
@@ -114,7 +114,7 @@ if [ "$RUST_OXIDE_ENABLED" = "1" ]; then
 	# If necessary, download and install latest Oxide
 	if [ "$INSTALL_OXIDE" = "1" ]; then
 		echo "Downloading and installing latest Oxide.."
-		OXIDE_URL=$(curl -s https://api.github.com/repos/OxideMod/Oxide.Rust/releases/latest | grep browser_download_url | cut -d '"' -f 4)
+		OXIDE_URL=$(curl -sL https://api.github.com/repos/OxideMod/Oxide.Rust/releases/latest | grep browser_download_url | cut -d '"' -f 4)
 		curl -sL $OXIDE_URL | bsdtar -xvf- -C /steamcmd/rust/
 		chmod 755 /steamcmd/rust/CSharpCompiler.x86_x64 2>&1 /dev/null
 		


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](../../CONTRIBUTING.md) to this repository.

- [x] Make sure to keep your code style as close to the original as possible
- [x] Make sure your code doesn't fail with the default or custom configuration

### Description
Cannot download Oxide because `https://api.github.com/repos/OxideMod/...(snip)` returns HTTP 301 redirect. Curl needs to follow that redirection.

before:
![2018-09-12_13h16_10](https://user-images.githubusercontent.com/4381346/45402332-1fceea00-b690-11e8-93ca-effef7da6efa.png)

after (applied `sed -i'.bak' -e '117s/curl\ -s/curl\ -sL/' /start.sh` and rerun docker container):
![2018-09-12_13h02_57](https://user-images.githubusercontent.com/4381346/45402360-412fd600-b690-11e8-95b5-122bc1e6dd05.png)
