### PR TITLE
Downloads uMod for Linux using "Develop" URL

### DIFF
--- a/start_rust.sh
+++ b/start_rust.sh
@@ -114,7 +114,7 @@ if [ "$RUST_OXIDE_ENABLED" = "1" ]; then
 	# If necessary, download and install latest Oxide
 	if [ "$INSTALL_OXIDE" = "1" ]; then
 		echo "Downloading and installing latest Oxide.."
-		OXIDE_URL=$(curl -sL https://api.github.com/repos/theumod/uMod.Rust/releases/latest | grep browser_download_url | cut -d '"' -f 4)
+		OXIDE_URL="https://umod.org/games/rust/download/develop"
 		curl -sL $OXIDE_URL | bsdtar -xvf- -C /steamcmd/rust/
 		chmod 755 /steamcmd/rust/CSharpCompiler.x86_x64 2>&1 /dev/null
 


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](../../CONTRIBUTING.md) to this repository.

- [x] Make sure to keep your code style as close to the original as possible
- [x] Make sure your code doesn't fail with the default or custom configuration

### Description

Fixes #50 

Since uMod has been split between Windows and Linux similar to Rust, uMod builds for Linux must be downloaded from the "Develop" URL.

Notice: Wulf says [the "Develop" URL is temporary.](https://umod.org/community/rust/12061-server-not-starting-when-oxide-is-installed?page=12#post-174)

Before:
![2019-09-18_17h34_31](https://user-images.githubusercontent.com/4381346/65135231-85db1380-da40-11e9-9db7-e7b9918b528a.png)
(Not responds here)

After:
![2019-09-18_17h52_22](https://user-images.githubusercontent.com/4381346/65135349-c044b080-da40-11e9-9122-d0b6242a5761.png)
(Rust dedicated server and uMod run successfully)